### PR TITLE
Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ problems with your application and _should_ crash the runtime. panicwrap
 is just meant as a way to monitor for panics. If you still think this is
 the worst idea ever, read the section below on why.
 
+Note: Since the main repository is archived, and there are a few long waited 
+PRs, this is a fork include those changes. These are the PRs:
+- https://github.com/mitchellh/panicwrap/pull/28 by https://github.com/brandonbloom
+- https://github.com/mitchellh/panicwrap/pull/27 by https://github.com/max-b
+- https://github.com/mitchellh/panicwrap/pull/20 by https://github.com/itizir
+
+
+
 ## Features
 
 * **SIMPLE!**

--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ import (
 )
 
 func main() {
-	exitStatus, err := panicwrap.BasicWrap(panicHandler)
+	done, exitStatus, err := panicwrap.BasicWrap(panicHandler)
 	if err != nil {
 		// Something went wrong setting up the panic wrapper. Unlikely,
 		// but possible.
 		panic(err)
 	}
 
-	// If exitStatus >= 0, then we're the parent process and the panicwrap
+	// If `done`, then we're the parent process and the panicwrap
 	// re-executed ourselves and completed. Just exit with the proper status.
-	if exitStatus >= 0 {
+	if done {
 		os.Exit(exitStatus)
 	}
 
-	// Otherwise, exitStatus < 0 means we're the child. Continue executing as
+	// Otherwise, `!done` means we're the child. Continue executing as
 	// normal...
 
 	// Let's say we panic

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mitchellh/panicwrap
+module github.com/mohsenpashna/panicwrap
 
-go 1.13
+go 1.23.2

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -280,7 +280,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 	panicBuf := new(bytes.Buffer)
 	panicHeaders := [][]byte{
 		[]byte("panic:"),
-		[]byte("fatal error: fault"),
+		[]byte("fatal error:"),
 	}
 	panicType := -1
 

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -170,8 +170,8 @@ func Wrap(c *WrapConfig) (bool, int, error) {
 
 	// Listen to signals and capture them forever. We allow the child
 	// process to handle them in some way.
-	sigCh := make(chan os.Signal)
-	fwdSigCh := make(chan os.Signal)
+	sigCh := make(chan os.Signal, 1)
+	fwdSigCh := make(chan os.Signal, 1)
 	if len(c.IgnoreSignals) == 0 {
 		c.IgnoreSignals = []os.Signal{os.Interrupt}
 	}

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -78,7 +78,7 @@ type WrapConfig struct {
 // BasicWrap calls Wrap with the given handler function, using defaults
 // for everything else. See Wrap and WrapConfig for more information on
 // functionality and return values.
-func BasicWrap(f HandlerFunc) (int, error) {
+func BasicWrap(f HandlerFunc) (bool, int, error) {
 	return Wrap(&WrapConfig{
 		Handler: f,
 	})
@@ -97,9 +97,9 @@ func BasicWrap(f HandlerFunc) (int, error) {
 //
 // Once this is called, the given WrapConfig shouldn't be modified or used
 // any further.
-func Wrap(c *WrapConfig) (int, error) {
+func Wrap(c *WrapConfig) (bool, int, error) {
 	if c.Handler == nil {
-		return -1, errors.New("Handler must be set")
+		return false, -1, errors.New("handler must be set")
 	}
 
 	if c.DetectDuration == 0 {
@@ -112,13 +112,13 @@ func Wrap(c *WrapConfig) (int, error) {
 
 	// If we're already wrapped, exit out.
 	if Wrapped(c) {
-		return -1, nil
+		return false, -1, nil
 	}
 
 	// Get the path to our current executable
 	exePath, err := os.Executable()
 	if err != nil {
-		return -1, err
+		return false, -1, err
 	}
 
 	// Pipe the stderr so we can read all the data as we look for panics
@@ -165,7 +165,7 @@ func Wrap(c *WrapConfig) (int, error) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		return 1, err
+		return true, 1, err
 	}
 
 	// Listen to signals and capture them forever. We allow the child
@@ -197,7 +197,7 @@ func Wrap(c *WrapConfig) (int, error) {
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
 			// This is some other kind of subprocessing error.
-			return 1, err
+			return true, 1, err
 		}
 
 		exitStatus := 1
@@ -218,10 +218,10 @@ func Wrap(c *WrapConfig) (int, error) {
 			c.Handler(panicTxt)
 		}
 
-		return exitStatus, nil
+		return true, exitStatus, nil
 	}
 
-	return 0, nil
+	return true, 0, nil
 }
 
 // Wrapped checks if we're already wrapped according to the configuration

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -60,13 +60,13 @@ func TestHelperProcess(*testing.T) {
 	cmd, args := args[0], args[1:]
 	switch cmd {
 	case "no-panic-ordered-output":
-		exitStatus, err := BasicWrap(panicHandler)
+		done, exitStatus, err := BasicWrap(panicHandler)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			for i := 0; i < 1000; i++ {
 				os.Stdout.Write([]byte("a"))
 				os.Stderr.Write([]byte("b"))
@@ -80,14 +80,14 @@ func TestHelperProcess(*testing.T) {
 		fmt.Fprint(os.Stderr, "stderr out")
 		os.Exit(0)
 	case "panic-boundary":
-		exitStatus, err := BasicWrap(panicHandler)
+		done, exitStatus, err := BasicWrap(panicHandler)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			// Simulate a panic but on two boundaries...
 			fmt.Fprint(os.Stderr, "pan")
 			os.Stderr.Sync()
@@ -98,14 +98,14 @@ func TestHelperProcess(*testing.T) {
 
 		os.Exit(exitStatus)
 	case "fatal":
-		exitStatus, err := BasicWrap(panicHandler)
+		done, exitStatus, err := BasicWrap(panicHandler)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
-			os.Exit(1)
+			os.Exit(exitStatus)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			// force a concurrent map error
 			badmap := make(map[int]int)
 			go func() {
@@ -118,14 +118,14 @@ func TestHelperProcess(*testing.T) {
 			}
 		}
 	case "panic-long":
-		exitStatus, err := BasicWrap(panicHandler)
+		done, exitStatus, err := BasicWrap(panicHandler)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			// Make a fake panic by faking the header and adding a
 			// bunch of garbage.
 			fmt.Fprint(os.Stderr, "panic: foo\n\n")
@@ -153,14 +153,14 @@ func TestHelperProcess(*testing.T) {
 			HidePanic: hidePanic,
 		}
 
-		exitStatus, err := Wrap(config)
+		done, exitStatus, err := Wrap(config)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			panic("uh oh")
 		}
 
@@ -174,13 +174,13 @@ func TestHelperProcess(*testing.T) {
 			Handler: panicHandler,
 		}
 
-		exitStatus, err := Wrap(config)
+		done, exitStatus, err := Wrap(config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)
 		}
 
-		if exitStatus < 0 {
+		if !done {
 			if child {
 				fmt.Printf("%v", Wrapped(nil))
 			}
@@ -201,7 +201,7 @@ func TestHelperProcess(*testing.T) {
 			os.Exit(0)
 		}
 
-		exitCode, err := Wrap(config)
+		_, exitCode, err := Wrap(config)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
 			os.Exit(1)

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -97,6 +97,26 @@ func TestHelperProcess(*testing.T) {
 		}
 
 		os.Exit(exitStatus)
+	case "fatal":
+		exitStatus, err := BasicWrap(panicHandler)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrap error: %s", err)
+			os.Exit(1)
+		}
+
+		if exitStatus < 0 {
+			// force a concurrent map error
+			badmap := make(map[int]int)
+			go func() {
+				for {
+					badmap[0] = 0
+				}
+			}()
+			for {
+				badmap[0] = 0
+			}
+		}
 	case "panic-long":
 		exitStatus, err := BasicWrap(panicHandler)
 
@@ -360,5 +380,21 @@ func TestWrapped_parent(t *testing.T) {
 
 	if !strings.Contains(stdout.String(), "false") {
 		t.Fatalf("bad: %#v", stdout.String())
+	}
+}
+
+func TestPanicWrap_fatal(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	p := helperProcess("fatal")
+	p.Stdout = stdout
+	p.Stderr = stderr
+	if err := p.Run(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if wrapRe.FindString(stdout.String()) == "" {
+		t.Fatalf("didn't wrap: %#v", stdout.String())
 	}
 }


### PR DESCRIPTION
This pull request includes several updates to the `panicwrap` module, primarily focused on improving error handling and updating the module's configuration. The changes include modifications to the `BasicWrap` and `Wrap` functions, updates to the `README.md` file, and adjustments to the test cases to accommodate the new function signatures.

Based are these suggested but not merges changes:
- https://github.com/mitchellh/panicwrap/pull/28 by https://github.com/brandonbloom
- https://github.com/mitchellh/panicwrap/pull/27 by https://github.com/max-b
- https://github.com/mitchellh/panicwrap/pull/20 by https://github.com/itizir

### Updates to `panicwrap` module:

* **Function Signature Changes:**
  - Updated `BasicWrap` and `Wrap` functions to return a boolean indicating if the process is done, along with the exit status and error. [[1]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L81-R81) [[2]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L100-R102)

* **Error Handling Improvements:**
  - Adjusted return values in `Wrap` function to return appropriate boolean and exit status in case of errors. [[1]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L115-R121) [[2]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L168-R174) [[3]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L200-R200) [[4]](diffhunk://#diff-c7e2f24db9c0c6a00a7dd9944c20f1e6e732f8e73a76a24a9fac3ad9e85c5a98L221-R224)

### Documentation Updates:

* **README.md:**
  - Added a note about the repository being a fork and included references to long-awaited pull requests from the original repository.
  - Updated code examples to reflect changes in the `BasicWrap` function signature.

### Module Configuration:

* **go.mod:**
  - Changed module path to `github.com/mohsenpashna/panicwrap` and updated Go version to 1.23.2.

### Test Case Updates:

* **panicwrap_test.go:**
  - Updated test cases to use the new `BasicWrap` and `Wrap` function signatures.
  - Added a new test case to handle fatal errors. [[1]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762L63-R69) [[2]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762L83-R90) [[3]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762R100-R128) [[4]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762L136-R163) [[5]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762L157-R183) [[6]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762L184-R204) [[7]](diffhunk://#diff-c9460b8be1f021ee7197a5358e9a8ad8b5c56aa21b87fec9c262b0ffd4089762R385-R400)